### PR TITLE
Engine refactoring and nefertari-es changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,6 @@ Backend and search engine for Nefertari
 
 Next tasks:
 
-- Find a way to specify/use multiple engines at once.
-
-- Need a way to delegate search to es (or other secondary
-  engine?). maybe just call `get_collection` on the generated es
-  model.
-
-- Need a way to generate an es model or mapping given an sql or mongo
-  model. this shouldn't be too hard, since the field names are mostly
-  the same.
-
-- Try to re-use existing part of the es engine. for example, probably
-  can re-use exiting base classes and fields in order to recreate
-  something like the existing `get_es_mapping`.
-
-- Will still need hooks in sql and mongo engines to update es models
-  when models are changed. it might make sense to change these hooks
-  to generate pyramid events. then the es engine can listen for these
-  events, thus de-coupling the engines.
-
 - Aggregations
 
 - Multi-collection requests
@@ -36,6 +17,7 @@ Next tasks:
 
 - Docstrings
 
+- Delete not used engines code related to ES (e.g. `get_es_mapping`)
 
 
 Advanced tasks:

--- a/nefertari_es/aggregation.py
+++ b/nefertari_es/aggregation.py
@@ -1,0 +1,147 @@
+import logging
+
+import six
+from nefertari import wrappers
+from nefertari.utils import dictset, validate_data_privacy
+from nefertari.json_httpexceptions import JHTTPForbidden, JHTTPBadRequest
+
+from nefertari_es.documents import BaseDocument
+
+log = logging.getLogger(__name__)
+
+
+def setup_aggregation(view, aggregator=None):
+    """ Wrap `view.index` method with `aggregator`.
+
+    This makes `view.index` to first try to run aggregation and only
+    on fail original method is run. Method is wrapped only if it is
+    defined and `elasticsearch.enable_aggregations` setting is true.
+    """
+    from nefertari_es import ESSettings
+    if aggregator is None:
+        aggregator = Aggregator
+    if not ESSettings.asbool('enable_aggregations'):
+        log.warning('Aggregations are not enabled')
+        return
+
+    index = getattr(view, 'index', None)
+    index_defined = index and index != view.not_allowed_action
+    if index_defined:
+        view.index = aggregator(view).wrap(view.index)
+
+
+class Aggregator(object):
+    """ Provides methods to perform Elasticsearch aggregations.
+
+    Example of using Aggregator:
+        >> # Create an instance with view
+        >> aggregator = Aggregator(view)
+        >> # Replace view.index with wrapped version
+        >> view.index = aggregator.wrap(view.index)
+
+    Attributes:
+        :_aggregations_keys: Sequence of strings representing name(s) of the
+            root key under which aggregations names are defined. Order of keys
+            matters - first key found in request is popped and returned. May be
+            overriden by defining it on view.
+
+    Examples:
+        If _aggregations_keys=('_aggregations',), then query string params
+        should look like:
+            _aggregations.min_price.min.field=price
+    """
+    _aggregations_keys = ('_aggregations', '_aggs')
+
+    def __init__(self, view):
+        self.view = view
+        view_aggregations_keys = getattr(view, '_aggregations_keys', None)
+        if view_aggregations_keys:
+            self._aggregations_keys = view_aggregations_keys
+
+    def wrap(self, func):
+        """ Wrap :func: to perform aggregation on :func: call.
+
+        Should be called with view instance methods.
+        """
+        @six.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return self.aggregate()
+            except KeyError as ex:
+                log.warning('Failed to aggregate: {}'.format(ex))
+                return func(*args, **kwargs)
+        return wrapper
+
+    def pop_aggregations_params(self):
+        """ Pop and return aggregation params from query string params.
+
+        Aggregation params are expected to be prefixed(nested under) by
+        any of `self._aggregations_keys`.
+        """
+        from nefertari.view import BaseView
+        self._query_params = BaseView.convert_dotted(self.view._query_params)
+
+        for key in self._aggregations_keys:
+            if key in self._query_params:
+                return self._query_params.pop(key)
+        else:
+            raise KeyError('Missing aggregation params')
+
+    def stub_wrappers(self):
+        """ Remove default 'index' after call wrappers and add only
+        those needed for aggregation results output.
+        """
+        self.view._after_calls['index'] = []
+
+    @classmethod
+    def get_aggregations_fields(cls, params):
+        """ Recursively get values under the 'field' key.
+
+        Is used to get names of fields on which aggregations should be
+        performed.
+        """
+        fields = []
+        for key, val in params.items():
+            if isinstance(val, dict):
+                fields += cls.get_aggregations_fields(val)
+            if key == 'field':
+                fields.append(val)
+        return fields
+
+    def check_aggregations_privacy(self, aggregations_params, model):
+        """ Check per-field privacy rules in aggregations.
+
+        Privacy is checked by making sure user has access to the fields
+        used in aggregations. Fields that don't belong to model are
+        not tested for privacy.
+        """
+        fields = self.get_aggregations_fields(aggregations_params)
+        fields = [f for f in fields if f in model.fields_to_query()]
+        fields_dict = dictset.fromkeys(fields)
+        fields_dict['_type'] = model.__name__
+
+        try:
+            validate_data_privacy(self.view.request, fields_dict)
+        except wrappers.ValidationError as ex:
+            raise JHTTPForbidden(
+                'Not enough permissions to aggregate on '
+                'fields: {}'.format(ex))
+
+    def aggregate(self):
+        """ Perform aggregation and return response. """
+        aggregations_params = self.pop_aggregations_params()
+        if self.view._auth_enabled:
+            self.check_aggregations_privacy(
+                aggregations_params, self.view.Model)
+        self.stub_wrappers()
+
+        if issubclass(self.view.Model, BaseDocument):
+            es_model = self.view.Model
+        elif issubclass(self.view.Model._secondary, BaseDocument):
+            es_model = self.view.Model._secondary
+        else:
+            raise JHTTPBadRequest('No ES-based model defined')
+
+        return es_model.aggregate(
+            _aggs_params=aggregations_params,
+            **self._query_params)

--- a/nefertari_es/fields.py
+++ b/nefertari_es/fields.py
@@ -15,6 +15,11 @@ class CustomMappingMixin(object):
     """
     _custom_mapping = None
 
+    def __init__(self, *args, **kwargs):
+        if 'mapping' in kwargs:
+            self._custom_mapping = kwargs.pop('mapping')
+        super(CustomMappingMixin, self).__init__(*args, **kwargs)
+
     def to_dict(self, *args, **kwargs):
         data = super(CustomMappingMixin, self).to_dict(*args, **kwargs)
         if self._custom_mapping is not None:
@@ -51,8 +56,15 @@ class IdField(CustomMappingMixin, BaseFieldMixin, field.String):
     def _empty(self):
         return None
 
+    def _to_python(self, data):
+        try:
+            data = str(data)
+        except:
+            pass
+        return super(IdField, self)._to_python(data)
 
-class IntervalField(BaseFieldMixin, field.Integer):
+
+class IntervalField(CustomMappingMixin, BaseFieldMixin, field.Integer):
     """ Custom field that stores `datetime.timedelta` instances.
 
     Values are stored as seconds in ES and loaded by
@@ -120,47 +132,47 @@ class TimeField(CustomMappingMixin, BaseFieldMixin, field.Field):
                 'Could not parse time from the value (%r)' % data, e)
 
 
-class IntegerField(BaseFieldMixin, field.Integer):
+class IntegerField(CustomMappingMixin, BaseFieldMixin, field.Integer):
     pass
 
 
-class SmallIntegerField(BaseFieldMixin, field.Integer):
+class SmallIntegerField(CustomMappingMixin, BaseFieldMixin, field.Integer):
     pass
 
 
-class StringField(BaseFieldMixin, field.String):
+class StringField(CustomMappingMixin, BaseFieldMixin, field.String):
     pass
 
 
-class TextField(BaseFieldMixin, field.String):
+class TextField(CustomMappingMixin, BaseFieldMixin, field.String):
     pass
 
 
-class UnicodeField(BaseFieldMixin, field.String):
+class UnicodeField(CustomMappingMixin, BaseFieldMixin, field.String):
     pass
 
 
-class UnicodeTextField(BaseFieldMixin, field.String):
+class UnicodeTextField(CustomMappingMixin, BaseFieldMixin, field.String):
     pass
 
 
-class BigIntegerField(BaseFieldMixin, field.Long):
+class BigIntegerField(CustomMappingMixin, BaseFieldMixin, field.Long):
     pass
 
 
-class BooleanField(BaseFieldMixin, field.Boolean):
+class BooleanField(CustomMappingMixin, BaseFieldMixin, field.Boolean):
     pass
 
 
-class FloatField(BaseFieldMixin, field.Float):
+class FloatField(CustomMappingMixin, BaseFieldMixin, field.Float):
     pass
 
 
-class BinaryField(BaseFieldMixin, field.Byte):
+class BinaryField(CustomMappingMixin, BaseFieldMixin, field.Byte):
     pass
 
 
-class DecimalField(BaseFieldMixin, field.Double):
+class DecimalField(CustomMappingMixin, BaseFieldMixin, field.Double):
     pass
 
 
@@ -168,6 +180,7 @@ class ReferenceField(BaseFieldMixin, field.String):
     _backref_prefix = 'backref_'
     _coerce = False
     _back_populates = None
+    _is_backref = False
     _valid_kwargs = ('required', 'multi')
 
     def __init__(self, doc_class, *args, **kwargs):
@@ -220,21 +233,23 @@ def Relationship(document, **kwargs):
 
 # Naive versions of fields needed to test example projects
 
-class ListField(BaseFieldMixin, field.String):
+class ListField(CustomMappingMixin, BaseFieldMixin, field.String):
     def __init__(self, *args, **kwargs):
         kwargs['multi'] = True
         super(ListField, self).__init__(*args, **kwargs)
 
 
-class ForeignKeyField(BaseFieldMixin, field.String):
+class ForeignKeyField(CustomMappingMixin, BaseFieldMixin, field.String):
     pass
 
 
-class ChoiceField(BaseFieldMixin, field.String):
+class ChoiceField(CustomMappingMixin, BaseFieldMixin, field.String):
     pass
 
 
-class PickleField(BaseFieldMixin, field.String):
+class PickleField(CustomMappingMixin, BaseFieldMixin, field.String):
+    _coerce = True
+
     def _to_python(self, data):
         if not data:
             return data

--- a/nefertari_es/polymorphic.py
+++ b/nefertari_es/polymorphic.py
@@ -1,0 +1,199 @@
+"""
+Module that defines all the objects required to handle polymorphic
+collection read requests.
+
+Im particular:
+    * PolymorphicACL: Dynamic factory class that generates ACL considering
+        ACLs of all the collections requested.
+    * PolymorphicView: View that handles polymorphic collection read
+        requests.
+
+This module is enabled by including it with Pyramid Configurator and
+specifying `elasticsearch.enable_polymorphic_query = true` setting in
+your .ini file.
+
+After inclusion, PolymorphicView view will be registered to handle GET
+requests. To access polymorphic API endpoint, compose URL with names
+used to access collection GET API endpoints.
+
+E.g. If API had collection endpoints '/users' and '/stories', polymorphic
+endpoint would be available at '/users,stories' and '/stories,users'.
+
+Polymorphic endpoints support all the read functionality regular ES
+endpoint supports: query, search, filter, sort, etc.
+"""
+from pyramid.security import DENY_ALL, Allow, ALL_PERMISSIONS
+
+from nefertari.view import BaseView
+from nefertari.acl import CollectionACL
+from nefertari.json_httpexceptions import JHTTPBadRequest
+from elasticsearch_dsl import Search
+
+from nefertari_es.documents import BaseDocument
+from nefertari_es.aggregation import Aggregator
+
+
+def includeme(config):
+    """ Connect view to route that catches all URIs like
+    'collection1,collection2,...'
+    """
+    root = config.get_root_resource()
+    root.add('nefes_polymorphic', '{collections:.+,.+}',
+             view=PolymorphicView,
+             factory=PolymorphicACL)
+
+
+class PolymorphicHelperMixin(object):
+    """ Helper mixin class that contains methods used by:
+        * PolymorphicACL
+        * PolymorphicView
+    """
+    def get_collections(self):
+        """ Get names of collections from request matchdict.
+
+        :return: Names of collections
+        :rtype: list of str
+        """
+        collections = self.request.matchdict['collections'].split('/')[0]
+        collections = [coll.strip() for coll in collections.split(',')]
+        return set(collections)
+
+    def get_resources(self, collections):
+        """ Get resources that correspond to values from :collections:.
+
+        :param collections: Collection names for which resources should be
+            gathered
+        :type collections: list of str
+        :return: Gathered resources
+        :rtype: list of Resource instances
+        """
+        res_map = self.request.registry._model_collections
+        resources = [res for res in res_map.values()
+                     if res.collection_name in collections]
+        resources = [res for res in resources if res]
+        return set(resources)
+
+
+class PolymorphicACL(PolymorphicHelperMixin, CollectionACL):
+    """ ACL used by PolymorphicView.
+
+    Generates ACEs checking whether current request user has 'view'
+    permissions in all of the requested collection views/contexts.
+    """
+    def __init__(self, request):
+        """ Set ACL generated from collections affected. """
+        super(PolymorphicACL, self).__init__(request)
+        self.set_collections_acl()
+
+    def _get_least_permissions_aces(self, resources):
+        """ Get ACEs with the least permissions that fit all resources.
+
+        To have access to polymorph on N collections, user MUST have
+        access to all of them. If this is true, ACEs are returned, that
+        allows 'view' permissions to current request principals.
+
+        Otherwise None is returned thus blocking all permissions except
+        those defined in `nefertari.acl.BaseACL`.
+
+        :param resources:
+        :type resources: list of Resource instances
+        :return: Generated Pyramid ACEs or None
+        :rtype: tuple or None
+        """
+        factories = [res.view._factory for res in resources]
+        contexts = [factory(self.request) for factory in factories]
+        for ctx in contexts:
+            if not self.request.has_permission('view', ctx):
+                return
+        else:
+            return [
+                (Allow, principal, 'view')
+                for principal in self.request.effective_principals
+            ]
+
+    def set_collections_acl(self):
+        """ Calculate and set ACL valid for requested collections.
+
+        DENY_ALL is added to ACL to make sure no access rules are
+        inherited.
+        """
+        acl = [(Allow, 'g:admin', ALL_PERMISSIONS)]
+        collections = self.get_collections()
+        resources = self.get_resources(collections)
+        aces = self._get_least_permissions_aces(resources)
+        if aces is not None:
+            for ace in aces:
+                acl.append(ace)
+        acl.append(DENY_ALL)
+        self.__acl__ = tuple(acl)
+
+
+class PolymorphicView(PolymorphicHelperMixin, BaseView):
+    """ Polymorphic collection read view.
+
+    Has default implementation of 'index' view method that supports
+    all the ES collection read actions(query, count, etc.) across
+    multiple collections of documents.
+
+    To be displayed by polymorphic view, model must have collection view
+    setup that serves instances of this model. Models that only have
+    singular views setup are not served by polymorhic view.
+    """
+    def __init__(self, *args, **kwargs):
+        super(PolymorphicView, self).__init__(*args, **kwargs)
+        self.es_models = self.get_es_models()
+
+    def _run_init_actions(self):
+        self.setup_default_wrappers()
+        self.set_public_limits()
+
+    def _setup_aggregation(self, *args, **kwargs):
+        kwargs['aggregator'] = PolymorphicAggregator
+        super(PolymorphicView, self)._setup_aggregation(*args, **kwargs)
+
+    def get_es_models(self):
+        """ Determine ES models from request data.
+
+        In particular `request.matchdict['collections']` is used to
+        determine types names. Its value is comma-separated sequence
+        of collection names under which views have been registered.
+
+        :returns: List of ES document types.
+        """
+        collections = self.get_collections()
+        resources = self.get_resources(collections)
+        models = set([res.view.Model for res in resources])
+        models = [mdl for mdl in models if mdl is not None]
+        es_models = []
+        for model in models:
+            if not issubclass(model, BaseDocument):
+                model = model._secondary
+            es_models.append(model)
+        return es_models
+
+    def index(self, collections):
+        """ Handle collection GET request. """
+        self._query_params.process_int_param('_limit', 20)
+        return BaseDocument.get_collection(
+            search_obj=Search(doc_type=self.es_models),
+            **self._query_params)
+
+
+class PolymorphicAggregator(Aggregator):
+    def aggregate(self):
+        """ Perform aggregation and return response. """
+        es_models = self.view.es_models
+        if not es_models:
+            raise JHTTPBadRequest('No ES-based model defined')
+
+        aggregations_params = self.pop_aggregations_params()
+        if self.view._auth_enabled:
+            for model in es_models:
+                self.check_aggregations_privacy(
+                    aggregations_params, model)
+        self.stub_wrappers()
+
+        return BaseDocument.aggregate(
+            _aggs_params=aggregations_params,
+            search_obj=Search(doc_type=es_models),
+            **self._query_params)

--- a/nefertari_es/scripts/index.py
+++ b/nefertari_es/scripts/index.py
@@ -1,0 +1,128 @@
+from argparse import ArgumentParser
+import sys
+import logging
+
+from pyramid.paster import bootstrap
+from pyramid.config import Configurator
+from six.moves import urllib
+
+from nefertari.utils import dictset, split_strip
+from nefertari import engine
+
+
+def main(argv=sys.argv):
+    logger = logging.getLogger()
+    logger.setLevel(logging.WARNING)
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    command = IndexCommand(argv, logger)
+    return command.run()
+
+
+class IndexCommand(object):
+    usage = '%prog config_uri <models'
+
+    def __init__(self, argv, logger):
+        parser = ArgumentParser(description=__doc__)
+        parser.add_argument(
+            '-c', '--config', help='config.ini (required)',
+            required=True)
+        parser.add_argument(
+            '--quiet', help='Quiet mode', action='store_true',
+            default=False)
+        parser.add_argument(
+            '--models',
+            help=('Comma-separated list of model names to index '
+                  '(required)'),
+            required=True)
+        parser.add_argument(
+            '--params', help='Url-encoded params for each model')
+        parser.add_argument(
+            '--force',
+            help=('Reindex all documents. By default only missing '
+                  'documents are indexed.'),
+            action='store_true',
+            default=False)
+        self._prepare_env(parser, logger)
+
+    def _prepare_env(self, parser, logger):
+        self.options = parser.parse_args()
+        if not self.options.config:
+            return parser.print_help()
+
+        env = bootstrap(self.options.config)
+        registry = env['registry']
+        # Include 'nefertari.engine' to setup engines
+        config = Configurator(settings=registry.settings)
+        config.include('nefertari.engine')
+
+        self.logger = logger
+        if not self.options.quiet:
+            self.logger.setLevel(logging.INFO)
+
+        self.settings = dictset(registry.settings)
+
+    def _nefertari_es_secondary(self):
+        import nefertari_es
+        from nefertari import engine
+        return engine.secondary is nefertari_es
+
+    def run(self):
+        if not self._nefertari_es_secondary():
+            self.logger.warning(
+                'Nothing to index: nefertari_es is not a secondary '
+                'engine')
+            return
+
+        model_names = split_strip(self.options.models)
+        for model_name in model_names:
+            self._index_model(model_name)
+
+    def _index_model(self, model_name):
+        self.logger.info('Processing model `{}`'.format(model_name))
+        model = engine.get_document_cls(model_name)
+        es_model = model._secondary
+
+        params = self.options.params or ''
+        params = dict([
+            [k, v[0]] for k, v in urllib.parse.parse_qs(params).items()
+        ])
+        db_queryset = model.get_collection(
+            _query_secondary=False, **params)
+
+        pk_field = es_model.pk_field()
+        db_pks = [getattr(dbobj, pk_field) for dbobj in db_queryset]
+        es_items = es_model.get_collection(**{pk_field: db_pks})
+
+        if self.options.force:
+            self.logger.info('Deleting existing `{}` documents'.format(
+                model_name))
+            es_model._delete_many(es_items)
+            self.logger.info('Indexing all `{}` documents'.format(
+                model_name))
+            missing_items = [item for item in db_queryset]
+        else:
+            self.logger.info('Indexing missing `{}` documents'.format(
+                model_name))
+            es_pks = [str(getattr(doc, pk_field)) for doc in es_items]
+            missing_items = [
+                item for item in db_queryset
+                if str(getattr(item, pk_field)) not in es_pks]
+
+        if not missing_items:
+            self.logger.info('Nothing to index')
+            return
+
+        self._index_docs(es_model, missing_items)
+
+    def _index_docs(self, es_model, db_items):
+        db_items_data = [itm.to_dict(_depth=0) for itm in db_items]
+        index_items = []
+        for data in db_items_data:
+            es_item = es_model(**data)
+            es_item._populate_meta_id()
+            index_items.append(es_item)
+        es_model._index_many(index_items)

--- a/nefertari_es/serializers.py
+++ b/nefertari_es/serializers.py
@@ -1,17 +1,14 @@
-import datetime
-import decimal
-
 from elasticsearch_dsl.serializer import AttrJSONSerializer
+from nefertari import engine
 
 
-class JSONSerializer(AttrJSONSerializer):
-    def default(self, obj):
-        if isinstance(obj, (datetime.datetime, datetime.date)):
-            return obj.strftime("%Y-%m-%dT%H:%M:%SZ")
-        if isinstance(obj, datetime.time):
-            return obj.strftime('%H:%M:%S')
-        if isinstance(obj, datetime.timedelta):
-            return obj.seconds
-        if isinstance(obj, decimal.Decimal):
-            return float(obj)
-        return super(JSONSerializer, self).default(obj)
+def get_json_serializer():
+    if engine.secondary is not None:
+        SerializerBase = engine.primary.JSONEncoder
+    else:
+        SerializerBase = engine.common.JSONEncoderMixin
+
+    class JSONSerializer(SerializerBase, AttrJSONSerializer):
+        pass
+
+    return JSONSerializer

--- a/nefertari_es/sync_handlers.py
+++ b/nefertari_es/sync_handlers.py
@@ -1,0 +1,82 @@
+from nefertari.engine import sync_events
+
+
+def includeme(config):
+    add_sub = config.add_subscriber
+    add_sub(handle_item_created, sync_events.ItemCreated)
+    add_sub(handle_item_updated, sync_events.ItemUpdated)
+    add_sub(handle_item_deleted, sync_events.ItemDeleted)
+    add_sub(handle_bulk_updated, sync_events.BulkUpdated)
+    add_sub(handle_bulk_deleted, sync_events.BulkDeleted)
+
+
+def handle_item_created(event):
+    item = event.item
+    es_model = item.__class__._secondary
+    item_data = item.to_dict(_depth=0)
+    es_model(**item_data).save()
+
+
+def handle_item_updated(event):
+    item = event.item
+    _update_item(item)
+
+
+def _update_item(item):
+    es_model = item.__class__._secondary
+    item_data = item.to_dict(_depth=0)
+    item_pk = item_data.pop('_pk', None)
+    pk_field = es_model.pk_field()
+    es_item = es_model.get_item(**{pk_field: item_pk})
+    es_item.update(item_data)
+
+
+def handle_item_deleted(event):
+    item = event.item
+    es_model = item.__class__._secondary
+    pk_field = es_model.pk_field()
+    item_pk = getattr(item, pk_field)
+    es_item = es_model.get_item(**{pk_field: item_pk})
+    es_item.delete()
+
+
+def _get_es_model(event):
+    items = event.items or []
+    try:
+        return items[0].__class__._secondary
+    except IndexError:
+        return None
+
+
+def _get_es_items(event):
+    items = event.items or []
+    es_model = _get_es_model(event)
+    if es_model is None or not items:
+        return
+    pk_field = es_model.pk_field()
+    item_ids = [getattr(item, pk_field) for item in items]
+    return es_model.get_collection(**{pk_field: item_ids})
+
+
+def handle_bulk_updated(event):
+    es_model = _get_es_model(event)
+    es_items = _get_es_items(event)
+    items = event.items or []
+    if not (es_model is not None and es_items and items):
+        return
+    pk_field = es_model.pk_field()
+    items = {str(getattr(item, pk_field)): item for item in items}
+    for es_item in es_items:
+        es_pk = str(getattr(es_item, pk_field))
+        db_item = items[es_pk]
+        db_item_data = db_item.to_dict(_depth=0)
+        es_item._pop_db_meta(db_item_data)
+        es_item._update(db_item_data)
+    es_model._index_many(es_items, request=event.request)
+
+
+def handle_bulk_deleted(event):
+    es_model = _get_es_model(event)
+    es_items = _get_es_items(event)
+    if es_model is not None and es_items:
+        es_model._delete_many(es_items, request=event.request)

--- a/nefertari_es/utils.py
+++ b/nefertari_es/utils.py
@@ -1,0 +1,15 @@
+from .fields import ReferenceField
+
+
+relationship_fields = (
+    ReferenceField,
+)
+
+
+def is_relationship_field(field, model_cls):
+    return field in model_cls._relationships()
+
+
+def get_relationship_cls(field, model_cls):
+    field_obj = model_cls._doc_type.mapping[field]
+    return field_obj._doc_class

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import (
     setup,
     find_packages,
-    )
+)
 
 
 install_requires = [
     'elasticsearch',
-    'elasticsearch-dsl',
+    'elasticsearch-dsl==0.0.8',
     'nefertari',
-    ]
+]
 
 
 setup(
@@ -35,4 +35,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,
+    entry_points="""\
+    [console_scripts]
+        nefertari_es.index = nefertari_es.scripts.index:main
+    """,
 )

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,0 +1,182 @@
+import pytest
+from mock import Mock, patch
+from nefertari.utils import dictset
+from nefertari.json_httpexceptions import JHTTPForbidden
+
+from nefertari_es.aggregation import Aggregator, setup_aggregation
+from nefertari_es import documents
+
+
+class TestAggregator(object):
+
+    class DemoView(object):
+        _aggregations_keys = ('test_aggregations',)
+        _query_params = dictset()
+        _json_params = dictset()
+
+    def test_pop_aggregations_params_query_string(self):
+        view = self.DemoView()
+        view._query_params = {'test_aggregations.foo': 1, 'bar': 2}
+        aggregator = Aggregator(view)
+        params = aggregator.pop_aggregations_params()
+        assert params == {'foo': 1}
+        assert aggregator._query_params == {'bar': 2}
+
+    def test_pop_aggregations_params_keys_order(self):
+        view = self.DemoView()
+        view._query_params = {
+            'test_aggregations.foo': 1,
+            'foobar': 2,
+        }
+        aggregator = Aggregator(view)
+        aggregator._aggregations_keys = ('test_aggregations', 'foobar')
+        params = aggregator.pop_aggregations_params()
+        assert params == {'foo': 1}
+        assert aggregator._query_params == {'foobar': 2}
+
+    def test_pop_aggregations_params_mey_error(self):
+        view = self.DemoView()
+        aggregator = Aggregator(view)
+        with pytest.raises(KeyError) as ex:
+            aggregator.pop_aggregations_params()
+        assert 'Missing aggregation params' in str(ex.value)
+
+    def test_stub_wrappers(self):
+        view = self.DemoView()
+        view._after_calls = {'index': [1, 2, 3], 'show': [1, 2]}
+        aggregator = Aggregator(view)
+        aggregator.stub_wrappers()
+        assert aggregator.view._after_calls == {'show': [1, 2], 'index': []}
+
+    def test_aggregate(self):
+        class Foo(documents.BaseDocument):
+            pass
+        Foo.aggregate = Mock()
+        view = self.DemoView()
+        view._auth_enabled = True
+        view.Model = Foo
+        aggregator = Aggregator(view)
+        aggregator.check_aggregations_privacy = Mock()
+        aggregator.stub_wrappers = Mock()
+        aggregator.pop_aggregations_params = Mock(return_value={'foo': 1})
+        aggregator._query_params = {'q': '2', 'zoo': 3}
+        aggregator.aggregate()
+        aggregator.stub_wrappers.assert_called_once_with()
+        aggregator.pop_aggregations_params.assert_called_once_with()
+        aggregator.check_aggregations_privacy.assert_called_once_with(
+            {'foo': 1}, view.Model)
+        Foo.aggregate.assert_called_once_with(
+            _aggs_params={'foo': 1}, q='2', zoo=3)
+
+    def test_get_aggregations_fields(self):
+        params = {
+            'min': {'field': 'foo'},
+            'histogram': {'field': 'bar', 'interval': 10},
+            'aggregations': {
+                'my_agg': {
+                    'max': {'field': 'baz'}
+                }
+            }
+        }
+        result = sorted(Aggregator.get_aggregations_fields(params))
+        assert result == sorted(['foo', 'bar', 'baz'])
+
+    @patch('nefertari.wrappers.apply_privacy')
+    def test_check_aggregations_privacy_all_allowed(self, mock_privacy):
+        view = self.DemoView()
+        view.request = 1
+        view.Model = Mock(__name__='Zoo')
+        view.Model.fields_to_query.return_value = ['foo', 'bar']
+        aggregator = Aggregator(view)
+        aggregator.get_aggregations_fields = Mock(return_value=['foo', 'bar'])
+        wrapper = Mock()
+        mock_privacy.return_value = wrapper
+        wrapper.return_value = {'foo': None, 'bar': None}
+        try:
+            aggregator.check_aggregations_privacy({'zoo': 2}, view.Model)
+        except JHTTPForbidden:
+            raise Exception('Unexpected error')
+        aggregator.get_aggregations_fields.assert_called_once_with({'zoo': 2})
+        mock_privacy.assert_called_once_with(1)
+        wrapper.assert_called_once_with(
+            result={'_type': 'Zoo', 'foo': None, 'bar': None})
+
+    @patch('nefertari.wrappers.apply_privacy')
+    def test_check_aggregations_privacy_not_allowed(self, mock_privacy):
+        view = self.DemoView()
+        view.request = 1
+        view.Model = Mock(__name__='Zoo')
+        view.Model.fields_to_query.return_value = ['foo', 'bar']
+        aggregator = Aggregator(view)
+        aggregator.get_aggregations_fields = Mock(return_value=['foo', 'bar'])
+        wrapper = Mock()
+        mock_privacy.return_value = wrapper
+        wrapper.return_value = {'bar': None}
+        with pytest.raises(JHTTPForbidden) as ex:
+            aggregator.check_aggregations_privacy({'zoo': 2}, view.Model)
+        expected = 'Not enough permissions to aggregate on fields: foo'
+        assert expected == str(ex.value)
+        aggregator.get_aggregations_fields.assert_called_once_with({'zoo': 2})
+        mock_privacy.assert_called_once_with(1)
+        wrapper.assert_called_once_with(
+            result={'_type': 'Zoo', 'foo': None, 'bar': None})
+
+    @patch('nefertari_es.aggregation.validate_data_privacy')
+    def test_check_aggregations_privacy_only_model_fields_passed(
+            self, mock_validate):
+        view = self.DemoView()
+        view.request = 1
+        view.Model = Mock(__name__='Zoo')
+        view.Model.fields_to_query.return_value = ['foo']
+        aggregator = Aggregator(view)
+        aggregator.get_aggregations_fields = Mock(return_value=['foo', 'bar'])
+        try:
+            aggregator.check_aggregations_privacy(
+                {'foo': 2, 'bar': 3}, view.Model)
+        except:
+            pass
+        mock_validate.assert_called_once_with(
+            1, {'foo': None, '_type': 'Zoo'})
+
+    def view_aggregations_keys_used(self):
+        view = self.DemoView()
+        view._aggregations_keys = ('foo',)
+        assert Aggregator(view)._aggregations_keys == ('foo',)
+        view._aggregations_keys = None
+        assert Aggregator(view)._aggregations_keys == (
+            '_aggregations', '_aggs')
+
+    def test_wrap(self):
+        view = self.DemoView()
+        view.index = Mock(__name__='foo')
+        aggregator = Aggregator(view)
+        aggregator.aggregate = Mock(side_effect=KeyError)
+        func = aggregator.wrap(view.index)
+        func(1, 2)
+        aggregator.aggregate.assert_called_once_with()
+        view.index.assert_called_once_with(1, 2)
+
+
+@patch('nefertari_es.aggregation.Aggregator')
+@patch('nefertari_es.ESSettings')
+class TestSetupAggregation(object):
+
+    def test_aggs_disabled(self, mock_set, mock_aggtr):
+        mock_set.asbool.return_value = False
+        setup_aggregation(1)
+        mock_set.asbool.assert_called_once_with('enable_aggregations')
+        assert not mock_aggtr.called
+
+    def test_index_not_defined(self, mock_set, mock_aggtr):
+        mock_set.asbool.return_value = True
+        view = Mock(index=None)
+        setup_aggregation(view)
+        assert not mock_aggtr.called
+
+    def test_index_defined(self, mock_set, mock_aggtr):
+        mock_set.asbool.return_value = True
+        view = Mock(index=1)
+        setup_aggregation(view)
+        mock_aggtr.assert_called_once_with(view)
+        mock_aggtr().wrap.assert_called_once_with(1)
+        assert view.index == mock_aggtr().wrap()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -229,12 +229,12 @@ class TestIdField(object):
             d.id = 'fail'
         assert str(e.value) == 'id is read-only'
 
-    def test_sync_id(self, id_model):
+    def test_populate_id_field(self, id_model):
         d = id_model()
         assert d.id is None
 
         # simulate a save
         d._id = 'ID'
-        d._sync_id_field()
+        d._populate_id_field()
 
         assert d.id == d._id

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -88,7 +88,7 @@ class TestGenerateMetaMixin(object):
         assert FooBar._doc_type.name == 'FooBar'
 
 
-class TestBackrefGeneratingDocMeta(object):
+class TestBackrefGeneratingDocMixin(object):
 
     def test_backref_generation(self):
         class Tag(documents.BaseDocument):
@@ -106,7 +106,9 @@ class TestBackrefGeneratingDocMeta(object):
         tag_stories = Tag._doc_type.mapping['stories']
         assert isinstance(tag_stories, fields.ReferenceField)
         assert tag_stories._back_populates == 'tags'
+        assert tag_stories._is_backref
         assert tag_stories._doc_class is Story
 
         story_tags = Story._doc_type.mapping['tags']
         assert story_tags._back_populates == 'stories'
+        assert not story_tags._is_backref

--- a/tests/test_polymorphic.py
+++ b/tests/test_polymorphic.py
@@ -1,0 +1,186 @@
+from mock import Mock, patch
+from nefertari.renderers import _JSONEncoder
+from nefertari.utils import dictset
+
+from nefertari_es import polymorphic, documents
+
+
+class TestPolymorphicHelperMixin(object):
+    def test_get_collections(self):
+        mixin = polymorphic.PolymorphicHelperMixin()
+        mixin.request = Mock(matchdict={
+            'collections': 'stories ,users,users/foo'})
+        assert mixin.get_collections() == set(['stories', 'users'])
+
+    def test_get_resources(self):
+        mixin = polymorphic.PolymorphicHelperMixin()
+        mixin.request = Mock()
+        resource1 = Mock(collection_name='stories')
+        resource2 = Mock(collection_name='foo')
+        mixin.request.registry._model_collections = {
+            'bar': resource1,
+            'baz': resource2,
+        }
+        resources = mixin.get_resources(['stories'])
+        assert resources == set([resource1])
+
+
+class TestPolymorphicACL(object):
+
+    @patch.object(polymorphic.PolymorphicACL, 'set_collections_acl')
+    def test_init(self, mock_meth):
+        polymorphic.PolymorphicACL(None)
+        mock_meth.assert_called_once_with()
+
+    @patch.object(polymorphic.PolymorphicACL, 'set_collections_acl')
+    def test_get_least_permissions_aces_not_allowed(self, mock_meth):
+        request = Mock()
+        request.has_permission.return_value = False
+        acl = polymorphic.PolymorphicACL(request)
+        resource = Mock()
+        resource.view._factory = Mock()
+        assert acl._get_least_permissions_aces([resource]) is None
+        resource.view._factory.assert_called_once_with(request)
+        request.has_permission.assert_called_once_with(
+            'view', resource.view._factory())
+
+    @patch.object(polymorphic.PolymorphicACL, 'set_collections_acl')
+    def test_get_least_permissions_aces_allowed(self, mock_meth):
+        from pyramid.security import Allow
+        request = Mock()
+        request.has_permission.return_value = True
+        request.effective_principals = ['user', 'admin']
+        acl = polymorphic.PolymorphicACL(request)
+        resource = Mock()
+        resource.view._factory = Mock()
+        aces = acl._get_least_permissions_aces([resource])
+        resource.view._factory.assert_called_once_with(request)
+        request.has_permission.assert_called_once_with(
+            'view', resource.view._factory())
+        assert len(aces) == 2
+        assert (Allow, 'user', 'view') in aces
+        assert (Allow, 'admin', 'view') in aces
+
+    @patch.object(polymorphic.PolymorphicACL, '_get_least_permissions_aces')
+    @patch.object(polymorphic.PolymorphicACL, 'get_resources')
+    @patch.object(polymorphic.PolymorphicACL, 'get_collections')
+    def test_set_collections_acl_no_aces(self, mock_coll, mock_res,
+                                         mock_aces):
+        from pyramid.security import DENY_ALL
+        mock_coll.return_value = ['stories', 'users']
+        mock_res.return_value = ['foo', 'bar']
+        mock_aces.return_value = None
+        acl = polymorphic.PolymorphicACL(None)
+        assert len(acl.__acl__) == 2
+        assert DENY_ALL == acl.__acl__[-1]
+        mock_coll.assert_called_once_with()
+        mock_res.assert_called_once_with(['stories', 'users'])
+        mock_aces.assert_called_once_with(['foo', 'bar'])
+
+    @patch.object(polymorphic.PolymorphicACL, '_get_least_permissions_aces')
+    @patch.object(polymorphic.PolymorphicACL, 'get_resources')
+    @patch.object(polymorphic.PolymorphicACL, 'get_collections')
+    def test_set_collections_acl_has_aces(self, mock_coll, mock_res,
+                                          mock_aces):
+        from pyramid.security import Allow, DENY_ALL
+        aces = [(Allow, 'foobar', 'dostuff')]
+        mock_aces.return_value = aces
+        acl = polymorphic.PolymorphicACL(None)
+        assert len(acl.__acl__) == 3
+        assert DENY_ALL == acl.__acl__[-1]
+        assert aces[0] in acl.__acl__
+        assert mock_coll.call_count == 1
+        assert mock_res.call_count == 1
+        assert mock_aces.call_count == 1
+
+
+class TestPolymorphicView(object):
+
+    class DummyPolymorphicView(polymorphic.PolymorphicView):
+        _json_encoder = _JSONEncoder
+
+    def _dummy_view(self):
+        request = Mock(content_type='', method='', accept=[''], user=None)
+        return self.DummyPolymorphicView(
+            context={}, request=request,
+            _json_params={'foo': 'bar'},
+            _query_params={'foo1': 'bar1'})
+
+    @patch.object(polymorphic.PolymorphicView, 'get_es_models')
+    @patch.object(polymorphic.PolymorphicView, 'set_public_limits')
+    @patch.object(polymorphic.PolymorphicView, 'setup_default_wrappers')
+    def test_run_init_actions(self, mock_wraps, mock_lims, mock_get):
+        self._dummy_view()
+        mock_wraps.assert_called_once_with()
+        mock_lims.assert_called_once_with()
+
+    @patch.object(polymorphic.PolymorphicView, 'get_resources')
+    @patch.object(polymorphic.PolymorphicView, 'get_collections')
+    def test_get_es_models(self, mock_coll, mock_res):
+        class StoryFoo(object):
+            _secondary = Mock(__name__='StoryFooSecondary')
+
+        class UserFoo(documents.BaseDocument):
+            pass
+
+        mock_coll.return_value = ['stories', 'users']
+        stories_res = Mock()
+        stories_res.view.Model = StoryFoo
+        users_res = Mock()
+        users_res.view.Model = UserFoo
+        mock_res.return_value = [stories_res, users_res]
+        view = self._dummy_view()
+        models = view.get_es_models()
+        assert len(models) == 2
+        assert set([m.__name__ for m in models]) == {
+            'StoryFooSecondary', 'UserFoo'}
+        mock_coll.assert_called_with()
+        mock_res.assert_called_with(['stories', 'users'])
+
+    @patch.object(polymorphic, 'Search')
+    @patch.object(polymorphic, 'BaseDocument')
+    @patch.object(polymorphic.PolymorphicView, 'get_es_models')
+    def test_index(self, mock_get, mock_doc, mock_search):
+        view = self._dummy_view()
+        response = view.index('zoo')
+        assert view._query_params['_limit'] == 20
+        mock_get.assert_called_once_with()
+        mock_search.assert_called_once_with(doc_type=mock_get())
+        mock_doc.get_collection.assert_called_once_with(
+            search_obj=mock_search(),
+            _limit=20, foo1='bar1')
+        assert response == mock_doc.get_collection()
+
+
+class TestPolymorphicAggregator(object):
+
+    class DemoView(object):
+        _aggregations_keys = ('test_aggregations',)
+        _query_params = dictset()
+        _json_params = dictset()
+
+    @patch('nefertari_es.polymorphic.Search')
+    @patch('nefertari_es.polymorphic.BaseDocument')
+    def test_aggregate(self, mock_doc, mock_search):
+        class Foo(documents.BaseDocument):
+            pass
+        Foo.aggregate = Mock()
+        view = self.DemoView()
+        view._auth_enabled = True
+        view.Model = Foo
+        view.es_models = [Foo]
+        aggregator = polymorphic.PolymorphicAggregator(view)
+        aggregator.check_aggregations_privacy = Mock()
+        aggregator.stub_wrappers = Mock()
+        aggregator.pop_aggregations_params = Mock(return_value={'foo': 1})
+        aggregator._query_params = {'q': '2', 'zoo': 3}
+        aggregator.aggregate()
+        aggregator.stub_wrappers.assert_called_once_with()
+        aggregator.pop_aggregations_params.assert_called_once_with()
+        aggregator.check_aggregations_privacy.assert_called_once_with(
+            {'foo': 1}, view.Model)
+        mock_search.assert_called_once_with(doc_type=[Foo])
+        mock_doc.aggregate.assert_called_once_with(
+            _aggs_params={'foo': 1},
+            search_obj=mock_search(),
+            q='2', zoo=3)

--- a/tests/test_script_index.py
+++ b/tests/test_script_index.py
@@ -1,0 +1,94 @@
+from mock import patch, Mock, call
+
+import nefertari_es
+from nefertari_es.scripts.index import IndexCommand
+
+
+@patch('nefertari_es.scripts.index.IndexCommand._prepare_env')
+class TestIndexCommand(object):
+
+    @patch('nefertari.engine')
+    def test_nefertari_es_secondary_true(self, mock_eng, mock_prep):
+        mock_eng.secondary = nefertari_es
+        cmd = IndexCommand(None, None)
+        assert cmd._nefertari_es_secondary()
+
+    @patch('nefertari.engine')
+    def test_nefertari_es_secondary_false(self, mock_eng, mock_prep):
+        mock_eng.secondary = None
+        cmd = IndexCommand(None, None)
+        assert not cmd._nefertari_es_secondary()
+
+    @patch('nefertari_es.scripts.index.IndexCommand._index_model')
+    @patch('nefertari.engine')
+    def test_run_not_secondary(self, mock_eng, mock_ind, mock_prep):
+        mock_eng.secondary = None
+        cmd = IndexCommand(None, None)
+        cmd.logger = Mock()
+        cmd.run()
+        assert not mock_ind.called
+
+    @patch('nefertari_es.scripts.index.IndexCommand._index_model')
+    @patch('nefertari.engine')
+    def test_run(self, mock_eng, mock_ind, mock_prep):
+        mock_eng.secondary = nefertari_es
+        cmd = IndexCommand(None, None)
+        cmd.options = Mock(models='User,  Foo')
+        cmd.logger = Mock()
+        cmd.run()
+        mock_ind.assert_has_calls([call('User'), call('Foo')])
+
+    def test_index_docs(self, mock_prep):
+        cmd = IndexCommand(None, None)
+        cmd.logger = Mock()
+        es_model = Mock()
+        item = Mock()
+        item.to_dict.return_value = {'foo': 1}
+        cmd._index_docs(es_model, [item])
+        item.to_dict.assert_called_once_with(_depth=0)
+        es_model.assert_called_once_with(foo=1)
+        es_model()._populate_meta_id.assert_called_once_with()
+        es_model._index_many.assert_called_once_with([es_model()])
+
+    @patch('nefertari_es.scripts.index.IndexCommand._index_docs')
+    @patch('nefertari_es.scripts.index.engine')
+    def test_index_model(self, mock_eng, mock_ind, mock_prep):
+        es_model = Mock()
+        es_model.pk_field.return_value = 'id'
+        es_model.get_collection.return_value = []
+        model = Mock(_secondary=es_model)
+        item = Mock(id=1)
+        model.get_collection.return_value = [item]
+        mock_eng.get_document_cls.return_value = model
+        cmd = IndexCommand(None, None)
+        cmd.logger = Mock()
+        cmd.options = Mock(force=False, params='foo=2')
+        cmd._index_model('Foo')
+        mock_eng.get_document_cls.assert_called_once_with('Foo')
+        model.get_collection.assert_called_once_with(
+            _query_secondary=False, foo='2')
+        es_model.get_collection.assert_called_once_with(id=[1])
+        assert not es_model._delete_many.called
+        mock_ind.assert_called_once_with(es_model, [item])
+
+    @patch('nefertari_es.scripts.index.IndexCommand._index_docs')
+    @patch('nefertari_es.scripts.index.engine')
+    def test_index_model_force(self, mock_eng, mock_ind, mock_prep):
+        es_model = Mock()
+        es_model.pk_field.return_value = 'id'
+        es_item = Mock(id=1)
+        es_model.get_collection.return_value = [es_item]
+        model = Mock(_secondary=es_model)
+        item = Mock(id=1)
+        model.get_collection.return_value = [item]
+        mock_eng.get_document_cls.return_value = model
+        cmd = IndexCommand(None, None)
+        cmd.logger = Mock()
+        cmd.options = Mock(force=True, params='foo=2')
+        cmd._index_model('Foo')
+        mock_eng.get_document_cls.assert_called_once_with('Foo')
+        model.get_collection.assert_called_once_with(
+            _query_secondary=False, foo='2')
+        es_model.get_collection.assert_called_once_with(id=[1])
+        es_model._delete_many.assert_called_once_with([es_item])
+        mock_ind.assert_called_once_with(es_model, [item])


### PR DESCRIPTION
Also fixes a privacy issue when performing aggregations on polymorphic views. Before it was possible to perform aggs on polymorphic route and fields which aren't available on regular collection requests (see PR #8).

Few things changed in indexation script:
  * `--index` option dropped. Use `elasticsearch.index_name` setting.
  * `--chunk` option dropped. Use `elasticsearch.chunk_size` setting.
  * `--force` option no longer recreates ES mapping, as deleting ES mapping is no longer supported in recent version of Elasticsearch. Now it deleted all matching documents of the type and indexes them again.

Script is now available at `nefertari_es.index` after installing nefertari-es.